### PR TITLE
Add multiple layout support

### DIFF
--- a/keyboards/jj40/jj40.h
+++ b/keyboards/jj40/jj40.h
@@ -22,6 +22,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode.h"
 #include "action.h"
 
+#define KEYMAP_GRID( \
+    K01, K02, K03, K04, K05, K06, K07, K08, K09, K010, K011, K012, \
+    K11, K12, K13, K14, K15, K16, K17, K18, K19, K110, K111, K112, \
+    K21, K22, K23, K24, K25, K26, K27, K28, K29, K210, K211, K212, \
+    K31, K32, K33, K34, K35, K36, K37, K38, K39, K310, K311, K312  \
+) \
+{ \
+  { K012, K011, K010, K09, K05, K06, K07, K08, K04, K03, K02, K01 }, \
+  { K112, K111, K110, K19, K15, K16, K17, K18, K14, K13, K12, K11 }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { K212, K211, K210, K29, K25, K26, K27, K28, K24, K23, K22, K21 }, \
+  { K312, K311, K310, K39, K35, K36, K37, K38, K34, K33, K32, K31 }  \
+}
+
 #define KEYMAP_MIT( \
     K01, K02, K03, K04, K05, K06, K07, K08, K09, K010, K011, K012, \
     K11, K12, K13, K14, K15, K16, K17, K18, K19, K110, K111, K112, \

--- a/keyboards/jj40/jj40.h
+++ b/keyboards/jj40/jj40.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode.h"
 #include "action.h"
 
-#define KEYMAP( \
+#define KEYMAP_MIT( \
     K01, K02, K03, K04, K05, K06, K07, K08, K09, K010, K011, K012, \
     K11, K12, K13, K14, K15, K16, K17, K18, K19, K110, K111, K112, \
     K21, K22, K23, K24, K25, K26, K27, K28, K29, K210, K211, K212, \
@@ -35,5 +35,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   { K212, K211, K210, K29, K25, K26, K27,   K28, K24, K23, K22, K21 }, \
   { K312, K311, K310, K39, K35, K3X, KC_NO, K38, K34, K33, K32, K31 }  \
 }
+
+#define KEYMAP_OFFSET( \
+    K01, K02, K03, K04, K05, K06, K07, K08, K09, K010, K011, K012, \
+    K11, K12, K13, K14, K15, K16, K17, K18, K19, K110, K111, K112, \
+    K21, K22, K23, K24, K25, K26, K27, K28, K29, K210, K211, K212, \
+    K31, K32, K33, K34, K35, K36,    K3X,   K39, K310, K311, K312  \
+) \
+{ \
+  { K012, K011, K010, K09, K05, K06, K07,   K08, K04, K03, K02, K01 }, \
+  { K112, K111, K110, K19, K15, K16, K17,   K18, K14, K13, K12, K11 }, \
+  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+  { K212, K211, K210, K29, K25, K26, K27,   K28, K24, K23, K22, K21 }, \
+  { K312, K311, K310, K39, K35, K36, K3X, KC_NO, K34, K33, K32, K31 }  \
+}
+
+#define KEYMAP KEYMAP_OFFSET
 
 #endif

--- a/keyboards/jj40/keymaps/oscillope/keymap.c
+++ b/keyboards/jj40/keymaps/oscillope/keymap.c
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "jj40.h"
+#include "action_layer.h"
+#include "rgblight.h"
+
+#define _QWERTY 0
+#define _LOWER  1
+#define _RAISE  2
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  LOWER,
+  RAISE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Esc  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Tab  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |Enter |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |   `  |   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Ctrl |  OS  | Alt  |Lower |Shift |Raise |    Space    | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = KEYMAP( \
+  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
+  KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
+  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT , \
+  KC_LCTL, KC_LGUI, KC_LALT, MO(_LOWER), KC_LSFT, MO(_RAISE),   KC_SPC,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT \
+),
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  | F10  | F11  | F12  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |      |      |      |      |      | Left | Down |  Up  |Right |      |      |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      | Back | Fwd  |      |      |      |      |      | Mute | Vol- | Vol+ |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Prev | Stop | Play | Next |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = KEYMAP( \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
+  KC_DEL,  _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, \
+  _______, KC_WBAK, KC_WFWD, _______, _______, _______, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, \
+  _______, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MSTP, KC_MPLY, KC_MNXT \
+),
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * | Esc  |   &  |   *  |   _  |   (  |   )  |   7  |   8  |   9  |   =  | Bksp | Del  |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Ins  |   $  |   %  |   ^  |   [  |   ]  |   4  |   5  |   6  |   -  |   +  |  |   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |   `  |   !  |   @  |   #  |   {  |   }  |   1  |   2  |   3  |   .  |   \  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Ctrl |  OS  | Alt  |      |Shift |      |      0      | Home | PgDn | PgUp | End  |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = KEYMAP( \
+  _______, KC_AMPR, KC_ASTR, KC_UNDS, KC_LPRN, KC_RPRN, KC_7,    KC_8,    KC_9,    KC_EQLS, KC_BSPC, KC_DEL, \
+  KC_INS,  KC_DLR,  KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_4,    KC_5,    KC_6,    KC_MINS, KC_PLUS, KC_PIPE, \
+  _______, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, _______, \
+  _______, _______, _______, _______, _______, _______, KC_0,    KC_HOME, KC_PGDN, KC_PGUP, KC_END \
+)
+};

--- a/keyboards/jj40/keymaps/oscillope/keymap.c
+++ b/keyboards/jj40/keymaps/oscillope/keymap.c
@@ -42,9 +42,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_QWERTY] = KEYMAP( \
-  KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
-  KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, \
-  KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT , \
+  KC_ESC,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC, \
+  KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_ENT, \
+  KC_GRV,  KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_QUOT, \
   KC_LCTL, KC_LGUI, KC_LALT, MO(_LOWER), KC_LSFT, MO(_RAISE),   KC_SPC,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT \
 ),
 
@@ -60,7 +60,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_LOWER] = KEYMAP( \
-  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC, \
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______, \
   KC_DEL,  _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, \
   _______, KC_WBAK, KC_WFWD, _______, _______, _______, _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______, \
   _______, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MSTP, KC_MPLY, KC_MNXT \
@@ -78,7 +78,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_RAISE] = KEYMAP( \
-  _______, KC_AMPR, KC_ASTR, KC_UNDS, KC_LPRN, KC_RPRN, KC_7,    KC_8,    KC_9,    KC_EQLS, KC_BSPC, KC_DEL, \
+  _______, KC_AMPR, KC_ASTR, KC_UNDS, KC_LPRN, KC_RPRN, KC_7,    KC_8,    KC_9,    KC_EQL,  KC_BSPC, KC_DEL, \
   KC_INS,  KC_DLR,  KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_4,    KC_5,    KC_6,    KC_MINS, KC_PLUS, KC_PIPE, \
   _______, KC_EXLM, KC_AT,   KC_HASH, KC_LCBR, KC_RCBR, KC_1,    KC_2,    KC_3,    _______, KC_BSLS, _______, \
   _______, _______, _______, _______, _______, _______, KC_0,    KC_HOME, KC_PGDN, KC_PGUP, KC_END \


### PR DESCRIPTION
This PR adds support for the "grid" layout (2x 1u keys instead of a 2u spacebar) and the "offset" layout (2u spacebar offset from center by 1u). It also contains a keymap which I use with the "offset" layout.